### PR TITLE
マップコマンドを追加。

### DIFF
--- a/src/main/java/net/azisaba/lgw/core/commands/LgwAdminCommand.java
+++ b/src/main/java/net/azisaba/lgw/core/commands/LgwAdminCommand.java
@@ -213,6 +213,24 @@ public class LgwAdminCommand implements CommandExecutor, TabCompleter {
             return true;
         }
 
+        // map なら
+        if ( Args.check(args, 0, "map") ) {
+            if ( Args.check(args, 1) ) {
+                Player p = Bukkit.getPlayer((args[2]));
+
+                if (p != null && p.isOnline()) {
+                    sender.sendMessage(Chat.f("&7{0}はワールド&8[&c{1}&&8]&7にいます。", p.getName(), p.getWorld().getName()));
+                    return true;
+                } else {
+                    sender.sendMessage(Chat.f("&l&7{0}&cはこのサーバーにいない、もしくは存在していません！", args[2]));
+                    return true;
+                }
+            } else {
+                sender.sendMessage(Chat.f("第二引数にプレイヤー名を指定してください！"));
+                return true;
+            }
+        }
+
         return true;
     }
 

--- a/src/main/java/net/azisaba/lgw/core/commands/MapCommand.java
+++ b/src/main/java/net/azisaba/lgw/core/commands/MapCommand.java
@@ -1,0 +1,24 @@
+package net.azisaba.lgw.core.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import net.azisaba.lgw.core.utils.Chat;
+
+
+public class MapCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(Chat.f("&cこのコマンドはプレイヤーのみ実行可能です"));
+            return true;
+        }
+
+        Player p = (Player) sender;
+
+        sender.sendMessage(Chat.f("&7あなたはワールド&8[&c{0}&&8]&7にいます。", p.getWorld().getName()));
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -32,6 +32,9 @@ commands:
   limit:
     usage: /limit [drop/build]
     permission: leongunwar.command.limit
+  map:
+    usage: /map
+    permission: leongunwar.command.map
 permissions:
   leongunwar.entrysign.changestate:
     default: op
@@ -55,3 +58,5 @@ permissions:
     default: op
   leongunwar.command.limit:
     default: op
+  leongunwar.command.map:
+    default: true


### PR DESCRIPTION
# 説明
## `/map`
- 機能：実行者がいるワールド名をチャットで返す
- 権限：全プレイヤー
- 文法：`/map`
- 起こりうるエラー：なし
## `/lgwadmin map`
- 機能：`[MCID]`のいるワールドをチャットで返す
- 権限：op
- 文法：`/lgwadmin map [MCID]`です。`[MCID]`にはオンラインのプレイヤー名を入れてください。
- 起こりうるエラー：MCIDが未記入の場合。MCIDが存在しないORオフラインの場合