### PR TITLE
経験値倍増ゲームのベース部分を実装

### DIFF
--- a/src/main/java/net/azisaba/lgw/core/LeonGunWar.java
+++ b/src/main/java/net/azisaba/lgw/core/LeonGunWar.java
@@ -194,7 +194,7 @@ public class LeonGunWar extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new JoinAfterSignListener(), this);
         Bukkit.getPluginManager().registerEvents(new CustomMatchSignListener(), this);
         Bukkit.getPluginManager().registerEvents(new MatchStartDetectListener(), this);
-        Bukkit.getPluginManager().registerEvents(new DamageListener(stats), this);
+        Bukkit.getPluginManager().registerEvents(new DamageListener(), this);
         Bukkit.getPluginManager().registerEvents(new PlayerControlListener(), this);
         Bukkit.getPluginManager().registerEvents(new QueueListener(),this);
 

--- a/src/main/java/net/azisaba/lgw/core/MatchManager.java
+++ b/src/main/java/net/azisaba/lgw/core/MatchManager.java
@@ -51,6 +51,7 @@ import net.azisaba.lgw.core.util.GameMap;
 import net.azisaba.lgw.core.util.KillDeathCounter;
 import net.azisaba.lgw.core.util.MapLoader;
 import net.azisaba.lgw.core.util.MatchMode;
+import net.azisaba.lgw.core.util.PlayerStats;
 import net.azisaba.lgw.core.utils.Chat;
 import net.azisaba.lgw.core.utils.CustomItem;
 import net.azisaba.lgw.core.utils.SecondOfDay;
@@ -61,6 +62,7 @@ import lombok.Data;
 import lombok.NonNull;
 
 import de.schlichtherle.io.util.LEDataOutputStream;
+import static net.azisaba.lgw.core.utils.LevelingUtils.getAngelOfDeathPercentage;
 
 /**
  * ゲームを司るコアクラス
@@ -987,6 +989,16 @@ public class MatchManager {
         } else {
             return 0;
         }
+    }
+
+    public boolean isXpBoost(List<Player> entryPlayers) {
+        // ↓見にくいですね。entryPlayers内ループを回して、AngelOfDeathLevelPercentageの平均の1.3倍を返してます
+        double avgPercentage = entryPlayers.stream().mapToDouble(p -> getAngelOfDeathPercentage(PlayerStats.getStats(p).getAngelOfDeathLevel())).sum() / entryPlayers.size() * 1.3; // TODO: avgPercentageの倍増率（今は1.3倍）を調整可能にするか、微調整。
+
+        Random random = new Random();
+        int seedLike = random.nextInt(100);
+
+        return seedLike <= avgPercentage; // < と <= どっち使えばいいかわからん
     }
 
     /**

--- a/src/main/java/net/azisaba/lgw/core/MatchManager.java
+++ b/src/main/java/net/azisaba/lgw/core/MatchManager.java
@@ -245,6 +245,7 @@ public class MatchManager {
             }
         }
 
+
         // 全プレイヤーに音を鳴らす
         Bukkit.getOnlinePlayers().forEach(p -> p.playSound(p.getLocation(), Sound.BLOCK_NOTE_PLING, 1, 1));
 
@@ -265,6 +266,14 @@ public class MatchManager {
 
         // 全プレイヤーにQuickメッセージを送信
         LeonGunWar.getQuickBar().send(Bukkit.getOnlinePlayers().toArray(new Player[0]));
+
+        // 倍増ゲームであった場合は音とタイトルで全プレイヤーに伝える
+        isCorrupted = isXpBoost(entryPlayers);
+        if (isCorrupted) {
+            currentGameMap.getWorld().setTime(18000); //真夜中にしてみた
+            Bukkit.getOnlinePlayers().forEach(p -> p.playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1, 1));
+            Bukkit.getOnlinePlayers().forEach(p -> p.sendTitle("&8&l&o!!!!&6&l&o経験値倍増ゲーム開始&8&l&o!!!!", "&7いつもよりもXPが多くもらえます！", 0, 40, 0));
+        }
     }
 
     public List<Player> getEntryPlayers() { return entryPlayers; }

--- a/src/main/java/net/azisaba/lgw/core/listeners/DamageListener.java
+++ b/src/main/java/net/azisaba/lgw/core/listeners/DamageListener.java
@@ -29,6 +29,8 @@ import net.azisaba.lgw.core.util.BattleTeam;
 import net.azisaba.lgw.core.util.PlayerStats;
 import net.azisaba.lgw.core.utils.Chat;
 
+import static net.azisaba.lgw.core.utils.LevelingUtils.getBaseIncreaseRate;
+
 public class DamageListener implements Listener {
     private final LevelingConfig config = LeonGunWar.getPlugin().getLevelingConfig();
     private PlayerStats stats;
@@ -69,12 +71,14 @@ public class DamageListener implements Listener {
         LeonGunWar.getPlugin().getManager().getKillDeathCounter().addKill(killer);
         // ポイントを追
         LeonGunWar.getPlugin().getManager().addTeamPoint(killerTeam);
-        // XP付与
-        if (LeonGunWar.getPlugin().getManager().isCorrupted()) { // 経験値倍増ゲームだったら
 
+        // XP付与
+        stats = PlayerStats.getStats(killer);
+        int baseIncreaseRate = getBaseIncreaseRate(stats.getXps());
+        if (LeonGunWar.getPlugin().getManager().isCorrupted()) { // 経験値倍増ゲームだったら
+            stats.addXps(baseIncreaseRate * 2); // TODO: 倍増率は絶対要検討！
         } else { // 経験値倍増ゲームじゃなかったら
-            stats = PlayerStats.getStats(killer);
-            stats.addXps((Integer) config.configmap.get("killXP"));
+            stats.addXps(baseIncreaseRate);
         }
 
         // タイトルを表示

--- a/src/main/java/net/azisaba/lgw/core/listeners/DamageListener.java
+++ b/src/main/java/net/azisaba/lgw/core/listeners/DamageListener.java
@@ -69,10 +69,13 @@ public class DamageListener implements Listener {
         LeonGunWar.getPlugin().getManager().getKillDeathCounter().addKill(killer);
         // ポイントを追
         LeonGunWar.getPlugin().getManager().addTeamPoint(killerTeam);
-        // levelingデータベースにキルプロセスを実行させる
         // XP付与
-        stats = PlayerStats.getStats(killer);
-        stats.addXps((Integer) config.configmap.get("killXP"));
+        if (LeonGunWar.getPlugin().getManager().isCorrupted()) { // 経験値倍増ゲームだったら
+
+        } else { // 経験値倍増ゲームじゃなかったら
+            stats = PlayerStats.getStats(killer);
+            stats.addXps((Integer) config.configmap.get("killXP"));
+        }
 
         // タイトルを表示
         killer.sendTitle("", Chat.f("&c+1 &7Kill"), 0, 10, 10);

--- a/src/main/java/net/azisaba/lgw/core/utils/LevelingUtils.java
+++ b/src/main/java/net/azisaba/lgw/core/utils/LevelingUtils.java
@@ -131,6 +131,24 @@ public class LevelingUtils {
     private static final int REQUIRED_ANGEL_TWELVE = 10000000;
     ///////////////////////////////////////////////////////////////
 
+    ///////////////////////////////////////////////////////////////
+    //BASE XP INCREASE RATE
+    ///////////////////////////////////////////////////////////////
+
+    private static final int BASE_INCREASE_RATE_50 = 1;
+    private static final int BASE_INCREASE_RATE_100 = 2;
+    private static final int BASE_INCREASE_RATE_200 = 3;
+    private static final int BASE_INCREASE_RATE_500 = 4;
+    private static final int BASE_INCREASE_RATE_1000 = 5;
+    private static final int BASE_INCREASE_RATE_2000 = 6;
+    private static final int BASE_INCREASE_RATE_5000 = 7;
+    private static final int BASE_INCREASE_RATE_10000 = 8;
+    private static final int BASE_INCREASE_RATE_40000 = 9;
+    private static final int BASE_INCREASE_RATE_100000 = 10;
+    private static final int BASE_INCREASE_RATE_UPPER = 15;
+
+    ///////////////////////////////////////////////////////////////
+
     public static int getRequiredXpsTotal(int level){
 
         int total = 0;
@@ -166,6 +184,32 @@ public class LevelingUtils {
             default: return 0;
         }
 
+    }
+
+    public static int getBaseIncreaseRate(int xp) {
+        if (xp <= 50) {
+            return BASE_INCREASE_RATE_50;
+        } else if (xp <= 100) {
+            return BASE_INCREASE_RATE_100;
+        } else if (xp <= 200) {
+            return BASE_INCREASE_RATE_200;
+        } else if (xp <= 500) {
+            return BASE_INCREASE_RATE_500;
+        } else if (xp <= 1000) {
+            return BASE_INCREASE_RATE_1000;
+        } else if (xp <= 2000) {
+            return BASE_INCREASE_RATE_2000;
+        } else if (xp <= 5000) {
+            return BASE_INCREASE_RATE_5000;
+        } else if (xp <= 10000) {
+            return BASE_INCREASE_RATE_10000;
+        } else if (xp <= 40000) {
+            return BASE_INCREASE_RATE_40000;
+        } else if (xp <= 100000) {
+            return BASE_INCREASE_RATE_100000;
+        } else {
+            return BASE_INCREASE_RATE_UPPER;
+        }
     }
 
     public static int getLevelFromXp(int xps){


### PR DESCRIPTION
やったこと：
- 経験値倍増ゲームになるかの確率的ランダム判定。
- 経験値レベルによってキル時の付与XPを変化させる。
- 経験値倍増ゲームの時に経験値を２倍に付与させる。
検討すべきところ：
- 経験値倍増ゲームの時にどのくらい経験値を倍増させるかを検討すべき。